### PR TITLE
fix: nas operation helper service support c1 & redeploy rule modifica…

### DIFF
--- a/src/lib/fc-deploy.ts
+++ b/src/lib/fc-deploy.ts
@@ -47,7 +47,7 @@ export default class FcDeploy {
 
       // 检测版本是否有变化
       if (!data?.description.includes(`VERSION: ${version}`)) {
-        logger.debug(`new version is ${version}, old version description ${data?.description}`);
+        logger.log(`new version is ${version}, old version is ${data?.description.split('VERSION:')[1]}`);
         return false;
       }
 
@@ -55,11 +55,15 @@ export default class FcDeploy {
       delete data.vpcConfig?.role;
       // @ts-ignore .
       delete vpcConfig?.role;
+      // @ts-ignore .
+      delete vpcConfig?.vswitchIds;
       const nasConfigCopy: any = _.cloneDeep(nasConfig);
       nasConfigCopy.mountPoints = nasConfig.mountPoints.map(({ serverAddr, fcDir, nasDir }) => ({
         serverAddr: `${serverAddr}:${makeSureNasUriStartWithSlash(nasDir)}`,
         mountDir: fcDir,
       }));
+      logger.debug(`data.vpcConfig, vpcConfig:: ${JSON.stringify(data.vpcConfig)} ${JSON.stringify(vpcConfig)}`);
+      logger.debug(`data.nasConfig, nasConfig:: ${JSON.stringify(data.nasConfig)} ${JSON.stringify(nasConfigCopy)}`);
       return _.isEqual(data.vpcConfig, vpcConfig) && _.isEqual(data.nasConfig, nasConfigCopy);
     } catch (ex) {
       logger.debug(`get service error: ${ex?.code}, ${ex?.message}`);


### PR DESCRIPTION
…tion

1. nas辅助函数修改为性能实例，之前有一个参数 NAS_HELPER_SERVERVICE_MEMORY_SIZE 用来管控辅助函数的执行内存，后面可以加一个判断，如果 memorySize >= 4096 就使用性能实例，小于则使用弹性实例
2. nas 的辅助函数每次都会强制覆盖之前的配置，经排查时 上层组件传入的 vpcConfig 存在了 vswitchIds和 vSwitchIds，导致每次验证 vpc 的配置总是异常
https://github.com/devsapp/fc/issues/390