### PR TITLE
feat: support shard download

### DIFF
--- a/examples/s.yml
+++ b/examples/s.yml
@@ -1,33 +1,31 @@
 edition: 1.0.0          #  命令行YAML规范版本，遵循语义化版本（Semantic Versioning）规范
 name: nasApp            #  项目名称
-access: default  #  秘钥别名
+access: default-1  #  秘钥别名
 
 services:
   nas-test: #  服务名称
     component: ${path(..)}  # 组件名称
     # component: devsapp/nas  # 组件名称
     props: #  组件的属性值
-      regionId: cn-shenzhen
+      regionId: cn-shanghai
       # 辅助函数使用
-      serviceName: express-2
+      serviceName: test-nas-8g2
       # description: 服务描述
       vpcConfig:
-        vpcId: vpc-wz9m008pvdv81787pkd8z
-        securityGroupId: sg-wz9add4h2zp98fe7ijyl
-        vSwitchIds: 
-          - vsw-wz9jlfu073piyq21lkom5
-
-      # 初始化 nas
-      nasDir: express-2
-      nasName: default_nas_created_by_fc_fun
-      zoneId: cn-shenzhen-a
-      storageType: Performance # Capacity
-
+        vpcId: vpc-uf638ir76pc2cevmfg246
+        securityGroupId: sg-uf6780p0snansz1dvusf
+        vSwitchIds:
+          - vsw-uf6p62lo20onpj48mpg60
       # 操作 nas
-      # groupId: 10003
-      # userId: 10003
-      # mountPoints:
-      #   - serverAddr: 2a14148c4e-wes85.cn-shenzhen.nas.aliyuncs.com
-      #     nasDir: /express-2
-      #     fcDir: /mnt/auto
+      userId: 10003
+      groupId: 10003
+      mountPoints:
+        - serverAddr: 31cf24b1e3-poa11.cn-shanghai.nas.aliyuncs.com
+          nasDir: /test-nas-8g2
+          fcDir: /mnt/auto
+      # 初始化 nas
+      # nasDir: express-2
+      # nasName: default_nas_created_by_fc_fun
+      # zoneId: cn-shenzhen-a
+      # storageType: Performance # Capacity
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "./dist/index.js",
   "autoInstall": false,
   "dependencies": {
-    "@alicloud/fc2": "^2.2.1",
+    "@alicloud/fc2": "^2.3.0",
     "@alicloud/pop-core": "^1.7.10",
     "@serverless-devs/core": "^0.0.x",
     "async": "^3.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,9 @@ export default class NasCompoent extends Base {
 
     checkInputs(props);
     const configPath = getConfigDirname(inputs?.path?.configPath);
-    const { 'no-unzip': noUnzip, 'no-clobber': noClobber } = commandData.data || {};
+    // --no 开头 commandParse 方法解析不出 true 这种参数
+    const noUnzip = commandData.data?.['no-unzip'] || args?.includes('--no-unzip');
+    const noClobber = commandData.data?.['no-clobber'] || args?.includes('--no-clobber');
     const [fcDir, localDir] = commandData.data?._ || [];
     const credentials = await getCredential(inputs.credentials, inputs);
     this.reportComponent('command', credentials.AccountID);
@@ -179,7 +181,8 @@ export default class NasCompoent extends Base {
     }
 
     checkInputs(props);
-    const { recursive, 'no-clobber': noClobber } = commandData.data || {};
+    const { recursive } = commandData.data || {};
+    const noClobber = commandData.data?.['no-clobber'] || args?.includes('--no-clobber');
     const [localDir, fcDir] = commandData.data?._ || [];
     const credentials = await getCredential(inputs.credentials, inputs);
     this.reportComponent('command', credentials.AccountID);

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {
 import EnsureNasDirInitHelperService from './lib/ensure-nas-dir-helper-service';
 import NasOperationInitHelperService from './lib/nas-operation-helper-service';
 import ParameterAdaptation from './lib/utils/parameter-adaptation';
-import { getCredential, makeSureNasUriStartWithSlash, argReplace } from './lib/utils/utils';
+import { getCredential, makeSureNasUriStartWithSlash, argReplace, getConfigDirname } from './lib/utils/utils';
 import { checkInputs } from './lib/command/utils';
 import Command from './lib/command/command';
 import Download from './lib/command/download';
@@ -112,7 +112,7 @@ export default class NasCompoent extends Base {
     logger.debug(`new input.props: ${JSON.stringify(props)}, inputs.args: ${args}`);
     const commandData: any = core.commandParse(inputs, APTS);
     logger.debug(`Command data is: ${JSON.stringify(commandData)}`);
-    if (commandData.data?.help) {
+    if (commandData.data?.help && !args?.includes('-lh')) {
       return core.help();
     }
 
@@ -148,13 +148,14 @@ export default class NasCompoent extends Base {
     }
 
     checkInputs(props);
+    const configPath = getConfigDirname(inputs?.path?.configPath);
     const { 'no-unzip': noUnzip, 'no-clobber': noClobber } = commandData.data || {};
     const [fcDir, localDir] = commandData.data?._ || [];
     const credentials = await getCredential(inputs.credentials, inputs);
     this.reportComponent('command', credentials.AccountID);
     await this.initHelperService(inputs);
     const download = new Download(credentials, props.regionId);
-    await download.cpFromNasToLocal(props, { localDir, fcDir: argReplace(fcDir), noUnzip, noClobber });
+    await download.cpFromNasToLocal(props, { localDir, fcDir: argReplace(fcDir), noUnzip, noClobber }, configPath);
   }
 
   /**

--- a/src/lib/command/command-base.ts
+++ b/src/lib/command/command-base.ts
@@ -52,8 +52,8 @@ export default class CommandBase {
     return await this.fcClient.get(urlPath, query);
   }
 
-  async callDownload(serviceName: string, tmpNasZipPath: string) {
+  async callDownload(serviceName: string, tmpNasZipPath: string, start: number, size: number) {
     const urlPath = `/proxy/${getServiceName(serviceName)}/${NAS_OPERATION_HELPER_FUNCTION_NAME}/download`;
-    return await this.fcClient.post(urlPath, { tmpNasZipPath }, {}, {}, { rawBuf: true });
+    return await this.fcClient.post(urlPath, { tmpNasZipPath, start, size }, {}, {}, { rawBuf: true });
   }
 }

--- a/src/lib/fc-deploy.ts
+++ b/src/lib/fc-deploy.ts
@@ -47,7 +47,7 @@ export default class FcDeploy {
 
       // 检测版本是否有变化
       if (!data?.description.includes(`VERSION: ${version}`)) {
-        logger.debug(`new version is ${version}, old version description ${data?.description}`);
+        logger.log(`new version is ${version}, old version is ${data?.description.split('VERSION:')[1]}`);
         return false;
       }
 
@@ -55,11 +55,15 @@ export default class FcDeploy {
       delete data.vpcConfig?.role;
       // @ts-ignore .
       delete vpcConfig?.role;
+      // @ts-ignore .
+      delete vpcConfig?.vswitchIds;
       const nasConfigCopy: any = _.cloneDeep(nasConfig);
       nasConfigCopy.mountPoints = nasConfig.mountPoints.map(({ serverAddr, fcDir, nasDir }) => ({
         serverAddr: `${serverAddr}:${makeSureNasUriStartWithSlash(nasDir)}`,
         mountDir: fcDir,
       }));
+      logger.debug(`data.vpcConfig, vpcConfig:: ${JSON.stringify(data.vpcConfig)} ${JSON.stringify(vpcConfig)}`);
+      logger.debug(`data.nasConfig, nasConfig:: ${JSON.stringify(data.nasConfig)} ${JSON.stringify(nasConfigCopy)}`);
       return _.isEqual(data.vpcConfig, vpcConfig) && _.isEqual(data.nasConfig, nasConfigCopy);
     } catch (ex) {
       logger.debug(`get service error: ${ex?.code}, ${ex?.message}`);

--- a/src/lib/utils/file.ts
+++ b/src/lib/utils/file.ts
@@ -18,7 +18,7 @@ export async function getFileStat(dirPath: string) {
  * @returns { start:, size }[]
  */
 export function splitRangeBySize(start: number, end: number) {
-  // 默认是 5M
+  // 默认是 4M
   const chunkSize = parseInt(process.env.NAS_CHUNK_SIZE || '4', 10) * 1024 * 1024;
 
   const res = [];

--- a/src/lib/utils/file.ts
+++ b/src/lib/utils/file.ts
@@ -19,7 +19,7 @@ export async function getFileStat(dirPath: string) {
  */
 export function splitRangeBySize(start: number, end: number) {
   // 默认是 5M
-  const chunkSize = parseInt(process.env.NAS_CHUNK_SIZE || '4.5', 10) * 1024 * 1024;
+  const chunkSize = parseInt(process.env.NAS_CHUNK_SIZE || '4', 10) * 1024 * 1024;
 
   const res = [];
   while (start < end) {

--- a/src/lib/utils/file.ts
+++ b/src/lib/utils/file.ts
@@ -1,0 +1,31 @@
+
+import fs from 'fs-extra';
+import logger from '../../common/logger';
+
+export async function getFileStat(dirPath: string) {
+  try {
+    return await fs.stat(dirPath);
+  } catch (ex) {
+    logger.debug(`getFileStat ${dirPath}: ${ex.code}, ${ex.message}`);
+    return false;
+  }
+}
+
+/**
+ * 将代码包切片
+ * @param start 计算量的起点
+ * @param end 计算量的终点
+ * @returns { start:, size }[]
+ */
+export function splitRangeBySize(start: number, end: number) {
+  // 默认是 5M
+  const chunkSize = parseInt(process.env.NAS_CHUNK_SIZE || '4.5', 10) * 1024 * 1024;
+
+  const res = [];
+  while (start < end) {
+    const size = Math.min(chunkSize, end - start);
+    res.push({ start, size });
+    start += size;
+  }
+  return res;
+}

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -4,7 +4,6 @@ import inquirer from 'inquirer';
 import _ from 'lodash';
 import fs from 'fs-extra';
 import path from 'path';
-import logger from '../../common/logger';
 
 export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -70,15 +69,14 @@ export function resolveLocalPath(localPath: string): string {
   return path.join(currentDir, localPath);
 }
 
-export async function getFileStat(dirPath: string) {
-  try {
-    return await fs.stat(dirPath);
-  } catch (ex) {
-    logger.debug(`getFileStat ${dirPath}: ${ex.code}, ${ex.message}`);
-    return false;
-  }
-}
-
 export function argReplace(fcDir) {
   return fcDir.replace(/nas:\/\//g, '');
+}
+
+export function getConfigDirname(configPath: string) {
+  if (configPath) {
+    return path.dirname(configPath);
+  }
+
+  return process.cwd();
 }


### PR DESCRIPTION
- 支持 nas 分片下载
- nas 的辅助函数每次都会强制覆盖之前的配置，经排查时 上层组件传入的 vpcConfig 存在了 vswitchIds和 vSwitchIds，导致每次验证 vpc 的配置总是异常
https://github.com/devsapp/fc/issues/390